### PR TITLE
feat(journal-crud): Basic Journal CRUD

### DIFF
--- a/src/models/Journal.js
+++ b/src/models/Journal.js
@@ -1,22 +1,61 @@
-import mongoose from "mongoose";
+import mongoose, { Schema } from "mongoose";
 
-const JournalSchema = new mongoose.Schema({
+const journalSchema = new mongoose.Schema({
   title: {
     type: String,
     required: true,
   },
+
   url: {
     type: String,
     required: true,
   },
+
   issn: {
     type: Number,
     required: true,
+    unique: true,
   },
-  domain: {
+
+  domainName: {
     type: String,
-    required: true,
+    required: false,
+  },
+
+  policies: {
+    title: {
+      type: String,
+      required: true,
+    },
+
+    firstYear: {
+      type: Number,
+      required: true,
+    },
+
+    lastYear: {
+      type: Number,
+    },
+
+    policyType: {
+      type: String,
+      required: true,
+    },
+  },
+
+  createdAt: {
+    type: Date,
+    immutable: true,
+  },
+
+  updatedAt: {
+    type: Date,
+  },
+
+  createdBy: {
+    type: Schema.Types.ObjectId,
+    ref: "User",
   },
 });
 
-export const Journal = mongoose.model("Journal", JournalSchema);
+export const Journal = mongoose.model("Journal", journalSchema);

--- a/src/resolvers/journalResolver.js
+++ b/src/resolvers/journalResolver.js
@@ -5,13 +5,33 @@ const journalResolver = {
     getAllJournals: async () => {
       return await Journal.find();
     },
+
+    getJournalByISSN: async (_, { issn }) => {
+      return await Journal.findOne({ issn });
+    },
   },
+
   Mutation: {
     createJournal: async (_, args) => {
-      const { title, url, issn, domain } = args.journal;
-      const journal = new Journal({ title, url, issn, domain });
+      const { title, url, issn, domainName, policies } = args.journal;
+      const journal = new Journal({ title, url, issn, domainName, policies });
       await journal.save();
       return journal;
+    },
+
+    deleteJournal: async (_, { issnToDelete }) => {
+      await Journal.deleteOne({ issn: issnToDelete });
+      return "Journal Deleted";
+    },
+
+    updateJournal: async (_, { issnToUpdate, newJournalDetails }) => {
+      const { title, url, domainName, issn, policies } = newJournalDetails;
+      const { _id } = await Journal.findOne({ issn: issnToUpdate });
+      await Journal.updateOne(
+        { _id },
+        { title, url, domainName, issn, policies }
+      );
+      return await Journal.findOne({ _id });
     },
   },
 };

--- a/src/types/journalType.js
+++ b/src/types/journalType.js
@@ -1,24 +1,52 @@
 import { gql } from "apollo-server-express";
 
 const journalType = gql`
+  type Policies {
+    title: String!
+    firstYear: Int!
+    lastYear: Int
+    policyType: String!
+  }
+
+  input PoliciesInput {
+    title: String!
+    firstYear: Int!
+    lastYear: Int
+    policyType: String!
+  }
+
   type Journal {
     id: ID
     title: String!
     url: String!
     issn: Int!
-    domain: String!
+    domainName: String!
+    policies: Policies!
+    createdAt: String
+    updatedAt: String
+    createdBy: String
   }
+
   input JournalInput {
     title: String!
     url: String!
     issn: Int!
-    domain: String!
+    domainName: String!
+    policies: PoliciesInput!
   }
+
   type Query {
-    getAllJournals: [Journal]!
+    getAllJournals: [Journal]
+    getJournalByISSN(issn: Int): Journal
   }
+
   type Mutation {
     createJournal(journal: JournalInput!): Journal!
+    deleteJournal(issnToDelete: Int!): String!
+    updateJournal(
+      issnToUpdate: Int!
+      newJournalDetails: JournalInput!
+    ): Journal!
   }
 `;
 


### PR DESCRIPTION
## #54

This PR builds on the `journalResolver` and adds more functionalities. Now we can do basic CRUD operations with the journal entity. More will be added on top of it in forthcoming PRs.

### Changes

 - Updated Journal `model` and `typeDefs`
 - Added `getJournalByISSN` Query
 - Added `deleteJournal` Mutation
 - Added `updateJournal` Mutation

### Flags
 - Newly added journal fields `createdAt`, `updatedAt` and `createdBy` do not auto-populate yet. This will be added in future PRs.

