### PR TITLE
feat: integrating user and journal

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "homepage": "https://github.com/d-e-v-esh/journal-policy-tracker-backend#readme",
   "dependencies": {
     "@graphql-tools/merge": "^8.2.14",
+    "@graphql-tools/schema": "^8.5.0",
     "apollo-server-express": "^3.8.2",
     "bcrypt": "^5.0.1",
     "connect-redis": "^6.1.3",
@@ -27,6 +28,8 @@
     "express": "^4.18.1",
     "express-session": "^1.17.3",
     "graphql": "^16.5.0",
+    "graphql-middleware": "^6.1.31",
+    "graphql-shield": "^7.5.0",
     "ioredis": "^5.1.0",
     "mongoose": "^6.3.6",
     "validator": "^13.7.0"

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,1 @@
+export const COOKIE_NAME = "obfc";

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import cors from "cors";
 import { applyMiddleware } from "graphql-middleware";
 import { authMiddleware } from "./middlewares/authMiddleware";
 import { makeExecutableSchema } from "@graphql-tools/schema";
+import { COOKIE_NAME } from "./constants";
 
 const startServer = async () => {
   const app = express();
@@ -38,7 +39,7 @@ const startServer = async () => {
 
   app.use(
     session({
-      name: "obfc",
+      name: COOKIE_NAME,
       store: new RedisStore({
         client: redis,
         disableTouch: true,

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { ApolloServer, gql } from "apollo-server-express";
+import { ApolloServer } from "apollo-server-express";
 import "dotenv/config";
 import express from "express";
 import mongoose from "mongoose";
@@ -8,6 +8,9 @@ import session from "express-session";
 import connectRedis from "connect-redis";
 import Redis from "ioredis";
 import cors from "cors";
+import { applyMiddleware } from "graphql-middleware";
+import { authMiddleware } from "./middlewares/authMiddleware";
+import { makeExecutableSchema } from "@graphql-tools/schema";
 
 const startServer = async () => {
   const app = express();
@@ -53,8 +56,10 @@ const startServer = async () => {
   );
 
   const server = new ApolloServer({
-    typeDefs,
-    resolvers,
+    schema: applyMiddleware(
+      makeExecutableSchema({ typeDefs, resolvers }),
+      authMiddleware
+    ),
     context: ({ req, res }) => ({ req, res, redis }),
   });
 

--- a/src/middlewares/authMiddleware.js
+++ b/src/middlewares/authMiddleware.js
@@ -1,0 +1,13 @@
+import { rule, shield } from "graphql-shield";
+
+const isAuthenticated = rule()((_, __, { req }) => {
+  return !!req.session.userId;
+});
+
+export const authMiddleware = shield({
+  Mutation: {
+    createJournal: isAuthenticated,
+    updateJournal: isAuthenticated,
+    deleteJournal: isAuthenticated,
+  },
+});

--- a/src/models/Journal.js
+++ b/src/models/Journal.js
@@ -20,7 +20,7 @@ const journalSchema = new mongoose.Schema(
 
     domainName: {
       type: String,
-      required: false,
+      required: true,
     },
 
     policies: {

--- a/src/models/Journal.js
+++ b/src/models/Journal.js
@@ -1,61 +1,58 @@
 import mongoose, { Schema } from "mongoose";
 
-const journalSchema = new mongoose.Schema({
-  title: {
-    type: String,
-    required: true,
-  },
-
-  url: {
-    type: String,
-    required: true,
-  },
-
-  issn: {
-    type: Number,
-    required: true,
-    unique: true,
-  },
-
-  domainName: {
-    type: String,
-    required: false,
-  },
-
-  policies: {
+const journalSchema = new mongoose.Schema(
+  {
     title: {
       type: String,
       required: true,
     },
 
-    firstYear: {
-      type: Number,
-      required: true,
-    },
-
-    lastYear: {
-      type: Number,
-    },
-
-    policyType: {
+    url: {
       type: String,
       required: true,
     },
+
+    issn: {
+      type: Number,
+      required: true,
+      unique: true,
+    },
+
+    domainName: {
+      type: String,
+      required: false,
+    },
+
+    policies: {
+      title: {
+        type: String,
+        required: true,
+      },
+
+      firstYear: {
+        type: Number,
+        required: true,
+      },
+
+      lastYear: {
+        type: Number,
+      },
+
+      policyType: {
+        type: String,
+        required: true,
+      },
+    },
+
+    createdBy: {
+      type: Schema.Types.ObjectId,
+      ref: "User",
+    },
   },
 
-  createdAt: {
-    type: Date,
-    immutable: true,
-  },
-
-  updatedAt: {
-    type: Date,
-  },
-
-  createdBy: {
-    type: Schema.Types.ObjectId,
-    ref: "User",
-  },
-});
+  {
+    timestamps: true,
+  }
+);
 
 export const Journal = mongoose.model("Journal", journalSchema);

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -5,25 +5,30 @@ const userSchema = new Schema({
     type: String,
     required: true,
   },
+
   username: {
     type: String,
     required: true,
     unique: true,
   },
+
   email: {
     type: String,
     required: true,
     unique: true,
     lowercase: true,
   },
+
   password: {
     type: String,
     required: true,
   },
+
   createdAt: {
     type: Date,
     required: true,
   },
+
   journals: [
     {
       type: Schema.Types.ObjectId,

--- a/src/resolvers/journalResolver.js
+++ b/src/resolvers/journalResolver.js
@@ -13,9 +13,18 @@ const journalResolver = {
 
   Mutation: {
     createJournal: async (_, { journalToCreate }) => {
-      const journal = new Journal({ ...journalToCreate });
-      await journal.save();
-      return journal;
+      let journal;
+      try {
+        journal = new Journal({ ...journalToCreate });
+        await journal.save();
+      } catch (error) {
+        if (error.code === 11000 && Object.keys(error.keyValue)[0] === "issn") {
+          return {
+            errors: [{ field: "issn", message: "issn already exists" }],
+          };
+        }
+      }
+      return { journal };
     },
 
     deleteJournal: async (_, { issnToDelete }) => {

--- a/src/resolvers/journalResolver.js
+++ b/src/resolvers/journalResolver.js
@@ -32,7 +32,12 @@ const journalResolver = {
       } catch (error) {
         if (error.code === 11000 && Object.keys(error.keyValue)[0] === "issn") {
           return {
-            errors: [{ field: "issn", message: "issn already exists" }],
+            errors: [
+              {
+                field: "issn",
+                message: "A journal with the same ISSN already exists",
+              },
+            ],
           };
         }
       }
@@ -63,7 +68,12 @@ const journalResolver = {
       } catch (error) {
         if (error.code === 11000 && Object.keys(error.keyValue)[0] === "issn") {
           return {
-            errors: [{ field: "issn", message: "new issn already exists" }],
+            errors: [
+              {
+                field: "issn",
+                message: "A journal with the same ISSN already exists",
+              },
+            ],
           };
         }
       }

--- a/src/resolvers/journalResolver.js
+++ b/src/resolvers/journalResolver.js
@@ -12,9 +12,8 @@ const journalResolver = {
   },
 
   Mutation: {
-    createJournal: async (_, args) => {
-      const { title, url, issn, domainName, policies } = args.journal;
-      const journal = new Journal({ title, url, issn, domainName, policies });
+    createJournal: async (_, { journalToCreate }) => {
+      const journal = new Journal({ ...journalToCreate });
       await journal.save();
       return journal;
     },
@@ -25,12 +24,8 @@ const journalResolver = {
     },
 
     updateJournal: async (_, { issnToUpdate, newJournalDetails }) => {
-      const { title, url, domainName, issn, policies } = newJournalDetails;
       const { _id } = await Journal.findOne({ issn: issnToUpdate });
-      await Journal.updateOne(
-        { _id },
-        { title, url, domainName, issn, policies }
-      );
+      await Journal.updateOne({ _id }, { ...newJournalDetails });
       return await Journal.findOne({ _id });
     },
   },

--- a/src/resolvers/journalResolver.js
+++ b/src/resolvers/journalResolver.js
@@ -34,8 +34,19 @@ const journalResolver = {
 
     updateJournal: async (_, { issnToUpdate, newJournalDetails }) => {
       const { _id } = await Journal.findOne({ issn: issnToUpdate });
-      await Journal.updateOne({ _id }, { ...newJournalDetails });
-      return await Journal.findOne({ _id });
+      try {
+        await Journal.updateOne({ _id }, { ...newJournalDetails });
+      } catch (error) {
+        if (error.code === 11000 && Object.keys(error.keyValue)[0] === "issn") {
+          return {
+            errors: [{ field: "issn", message: "issn already exists" }],
+          };
+        }
+      }
+
+      const updatedJournal = await Journal.findOne({ _id });
+
+      return { journal: updatedJournal };
     },
   },
 };

--- a/src/resolvers/journalResolver.js
+++ b/src/resolvers/journalResolver.js
@@ -28,12 +28,18 @@ const journalResolver = {
     },
 
     deleteJournal: async (_, { issnToDelete }) => {
-      await Journal.deleteOne({ issn: issnToDelete });
-      return "Journal Deleted";
+      const { deletedCount } = await Journal.deleteOne({ issn: issnToDelete });
+
+      if (deletedCount === 0) {
+        return false;
+      }
+
+      return true;
     },
 
     updateJournal: async (_, { issnToUpdate, newJournalDetails }) => {
       const { _id } = await Journal.findOne({ issn: issnToUpdate });
+
       try {
         await Journal.updateOne({ _id }, { ...newJournalDetails });
       } catch (error) {

--- a/src/resolvers/journalResolver.js
+++ b/src/resolvers/journalResolver.js
@@ -38,20 +38,26 @@ const journalResolver = {
     },
 
     updateJournal: async (_, { issnToUpdate, newJournalDetails }) => {
-      const { _id } = await Journal.findOne({ issn: issnToUpdate });
+      const journalToUpdate = await Journal.findOne({ issn: issnToUpdate });
 
+      if (!journalToUpdate) {
+        return {
+          errors: [{ field: "issn", message: "issn not available" }],
+        };
+      }
+
+      const { _id } = journalToUpdate;
       try {
         await Journal.updateOne({ _id }, { ...newJournalDetails });
       } catch (error) {
         if (error.code === 11000 && Object.keys(error.keyValue)[0] === "issn") {
           return {
-            errors: [{ field: "issn", message: "issn already exists" }],
+            errors: [{ field: "issn", message: "new issn already exists" }],
           };
         }
       }
 
       const updatedJournal = await Journal.findOne({ _id });
-
       return { journal: updatedJournal };
     },
   },

--- a/src/resolvers/userResolver.js
+++ b/src/resolvers/userResolver.js
@@ -12,7 +12,7 @@ const userResolver = {
         return null;
       }
 
-      return User.findOne({ _id: req.session.userId });
+      return await User.findById(req.session.userId);
     },
     getAllUsers: async () => {
       return await User.find();

--- a/src/resolvers/userResolver.js
+++ b/src/resolvers/userResolver.js
@@ -1,6 +1,7 @@
 import { User } from "../models/User";
 import validator from "validator";
 import bcrypt from "bcrypt";
+import { COOKIE_NAME } from "../constants";
 
 const saltRounds = 12;
 
@@ -94,6 +95,25 @@ const userResolver = {
 
       req.session.userId = user.id;
       return { user };
+    },
+
+    logout: (_, __, { req, res }) => {
+      return new Promise((resolve) =>
+        req.session.destroy((err) => {
+          res.clearCookie(COOKIE_NAME, {
+            // Cookie options should be changed or removed before we go in prod
+            sameSite: "none",
+            secure: true,
+          });
+          if (err) {
+            console.log(err);
+            resolve(false);
+            return;
+          }
+
+          resolve(true);
+        })
+      );
     },
   },
 };

--- a/src/types/journalType.js
+++ b/src/types/journalType.js
@@ -35,18 +35,28 @@ const journalType = gql`
     policies: PoliciesInput!
   }
 
+  type JournalResponse {
+    journal: Journal
+    errors: [Error]
+  }
+
+  type Error {
+    field: String!
+    message: String!
+  }
+
   type Query {
     getAllJournals: [Journal]
     getJournalByISSN(issn: Int): Journal
   }
 
   type Mutation {
-    createJournal(journalToCreate: JournalInput!): Journal!
+    createJournal(journalToCreate: JournalInput!): JournalResponse!
     deleteJournal(issnToDelete: Int!): String!
     updateJournal(
       issnToUpdate: Int!
       newJournalDetails: JournalInput!
-    ): Journal!
+    ): JournalResponse!
   }
 `;
 

--- a/src/types/journalType.js
+++ b/src/types/journalType.js
@@ -22,9 +22,9 @@ const journalType = gql`
     issn: Int!
     domainName: String!
     policies: Policies!
-    createdAt: String
-    updatedAt: String
-    createdBy: String
+    createdAt: String!
+    updatedAt: String!
+    createdBy: String!
   }
 
   input JournalInput {

--- a/src/types/journalType.js
+++ b/src/types/journalType.js
@@ -41,7 +41,7 @@ const journalType = gql`
   }
 
   type Mutation {
-    createJournal(journal: JournalInput!): Journal!
+    createJournal(journalToCreate: JournalInput!): Journal!
     deleteJournal(issnToDelete: Int!): String!
     updateJournal(
       issnToUpdate: Int!

--- a/src/types/journalType.js
+++ b/src/types/journalType.js
@@ -52,7 +52,7 @@ const journalType = gql`
 
   type Mutation {
     createJournal(journalToCreate: JournalInput!): JournalResponse!
-    deleteJournal(issnToDelete: Int!): String!
+    deleteJournal(issnToDelete: Int!): Boolean!
     updateJournal(
       issnToUpdate: Int!
       newJournalDetails: JournalInput!

--- a/src/types/userType.js
+++ b/src/types/userType.js
@@ -38,6 +38,7 @@ const userType = gql`
   type Mutation {
     register(userInfo: RegisterInput!): UserResponse!
     login(userInfo: LoginInput!): UserResponse!
+    logout: Boolean!
   }
 `;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -970,6 +970,13 @@
     pirates "^4.0.5"
     source-map-support "^0.5.16"
 
+"@babel/runtime@^7.10.5":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.6.tgz#6a1ef59f838debd670421f8c7f2cbb8da9751580"
+  integrity sha512-t9wi7/AW6XtKahAe20Yw0/mMljKq0B1r2fPdvaAdV/KPDZewFXdaaa6K7lxmZBZ8FBNpCiAT6iHPmd6QO9bKfQ==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.8.4":
   version "7.18.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.3.tgz#c7b654b57f6f63cf7f8b418ac9ca04408c4579f4"
@@ -1010,12 +1017,42 @@
     "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
 
+"@graphql-tools/batch-execute@8.5.0":
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/batch-execute/-/batch-execute-8.5.0.tgz#2767a9abf4e2712871a69360a27ef13ada1c019e"
+  integrity sha512-S9/76X4uYIbVlJyRzXhCBbTJvVD0VvaWNqGiKgkITxlq4aBsTOHVuE84OSi3E1QKP3PTiJYrgMIn220iFOkyQw==
+  dependencies:
+    "@graphql-tools/utils" "8.8.0"
+    dataloader "2.1.0"
+    tslib "^2.4.0"
+    value-or-promise "1.0.11"
+
+"@graphql-tools/delegate@^8.8.0":
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/delegate/-/delegate-8.8.0.tgz#acd3e48e4ca82aace92cc3d920b5c727c35eaf7b"
+  integrity sha512-dbhfOI8rQXPcowXrbwHLOBY9oGi7qxtlrXF4RuRXmjqGTs2AgogdOE3Ep1+6wFD7qYTuFmHXZ8Cl0PmhoZUgrg==
+  dependencies:
+    "@graphql-tools/batch-execute" "8.5.0"
+    "@graphql-tools/schema" "8.5.0"
+    "@graphql-tools/utils" "8.8.0"
+    dataloader "2.1.0"
+    tslib "~2.4.0"
+    value-or-promise "1.0.11"
+
 "@graphql-tools/merge@8.2.14", "@graphql-tools/merge@^8.2.14":
   version "8.2.14"
   resolved "https://registry.yarnpkg.com/@graphql-tools/merge/-/merge-8.2.14.tgz#44811e5453f5515d9537bd1b64f0f0cfe6313a45"
   integrity sha512-od6lTF732nwPX91G79eiJf+dyRBHxCaKe7QL4IYeH4d1k+NYqx/ihYpFJNjDaqxmpHH92Hr+TxsP9SYRK3/QKg==
   dependencies:
     "@graphql-tools/utils" "8.6.13"
+    tslib "^2.4.0"
+
+"@graphql-tools/merge@8.3.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/merge/-/merge-8.3.0.tgz#d3a8ba10942f8598788c3e03f97cc1d0c0b055f8"
+  integrity sha512-xRa7RAQok/0DD2YnjuqikMrr7dUAxTpdGtZ7BkvUUGhYs3B3p7reCAfvOVr1DJAqVToP7hdlMk+S5+Ylk+AaqA==
+  dependencies:
+    "@graphql-tools/utils" "8.8.0"
     tslib "^2.4.0"
 
 "@graphql-tools/mock@^8.1.2":
@@ -1038,10 +1075,27 @@
     tslib "^2.4.0"
     value-or-promise "1.0.11"
 
+"@graphql-tools/schema@8.5.0", "@graphql-tools/schema@^8.5.0":
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-8.5.0.tgz#0332b3a2e674d16e9bf8a58dfd47432449ce2368"
+  integrity sha512-VeFtKjM3SA9/hCJJfr95aEdC3G0xIKM9z0Qdz4i+eC1g2fdZYnfWFt2ucW4IME+2TDd0enHlKzaV0qk2SLVUww==
+  dependencies:
+    "@graphql-tools/merge" "8.3.0"
+    "@graphql-tools/utils" "8.8.0"
+    tslib "^2.4.0"
+    value-or-promise "1.0.11"
+
 "@graphql-tools/utils@8.6.13":
   version "8.6.13"
   resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.6.13.tgz#2b4fb7f9f8a29b25eecd44551fb95974de32f969"
   integrity sha512-FiVqrQzj4cgz0HcZ3CxUs8NtBGPZFpmsVyIgwmL6YCwIhjJQnT72h8G3/vk5zVfjfesht85YGp0inWWuoCKWzg==
+  dependencies:
+    tslib "^2.4.0"
+
+"@graphql-tools/utils@8.8.0":
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.8.0.tgz#8332ff80a1da9204ccf514750dd6f5c5cccf17dc"
+  integrity sha512-KJrtx05uSM/cPYFdTnGAS1doL5bftJLAiFCDMZ8Vkifztz3BFn3gpFiy/o4wDtM8s39G46mxmt2Km/RmeltfGw==
   dependencies:
     tslib "^2.4.0"
 
@@ -1276,6 +1330,11 @@
   dependencies:
     "@types/node" "*"
     "@types/webidl-conversions" "*"
+
+"@types/yup@0.29.11":
+  version "0.29.11"
+  resolved "https://registry.yarnpkg.com/@types/yup/-/yup-0.29.11.tgz#d654a112973f5e004bf8438122bd7e56a8e5cd7e"
+  integrity sha512-9cwk3c87qQKZrT251EDoibiYRILjCmxBvvcb4meofCmx1vdnNcR9gyildy5vOHASpOKMsn42CugxUvcwK5eu1g==
 
 abbrev@1:
   version "1.1.1"
@@ -1835,6 +1894,11 @@ cssfilter@0.0.10:
   resolved "https://registry.yarnpkg.com/cssfilter/-/cssfilter-0.0.10.tgz#c6d2672632a2e5c83e013e6864a42ce8defd20ae"
   integrity sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==
 
+dataloader@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.1.0.tgz#c69c538235e85e7ac6c6c444bae8ecabf5de9df7"
+  integrity sha512-qTcEYLen3r7ojZNgVUaRggOI+KM7jrKxXeSHhogh/TWxYMeONEMqY+hmkobiYQozsGIyg9OYVzO4ZIfoB4I0pQ==
+
 debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -2271,6 +2335,23 @@ graceful-fs@^4.1.2:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
+graphql-middleware@^6.1.31:
+  version "6.1.31"
+  resolved "https://registry.yarnpkg.com/graphql-middleware/-/graphql-middleware-6.1.31.tgz#4995d0bad931d2b6d08238d40058fdc8ece4bc5b"
+  integrity sha512-czfWgc84LK7xjV6i34Ky8BXtTKgdstHO4jsr/4wHJTxNQ07YH93Qlg7gaZpqNwK1ipdC4xCbfxQ5thDdnFR+Yw==
+  dependencies:
+    "@graphql-tools/delegate" "^8.8.0"
+    "@graphql-tools/schema" "^8.5.0"
+
+graphql-shield@^7.5.0:
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/graphql-shield/-/graphql-shield-7.5.0.tgz#aa3af226946946dfadac33eccc6cbe7fec6e9000"
+  integrity sha512-T1A6OreOe/dHDk/1Qg3AHCrKLmTkDJ3fPFGYpSOmUbYXyDnjubK4J5ab5FjHdKHK5fWQRZNTvA0SrBObYsyfaw==
+  dependencies:
+    "@types/yup" "0.29.11"
+    object-hash "^2.0.3"
+    yup "^0.31.0"
+
 graphql-tag@^2.11.0:
   version "2.12.6"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.6.tgz#d441a569c1d2537ef10ca3d1633b48725329b5f1"
@@ -2669,6 +2750,11 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
+lodash-es@^4.17.11:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
+
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
@@ -2688,6 +2774,11 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==
+
+lodash@^4.17.20:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 loglevel@^1.6.8:
   version "1.8.0"
@@ -2950,6 +3041,11 @@ object-assign@^4, object-assign@^4.1.1:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
 
+object-hash@^2.0.3:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.2.0.tgz#5ad518581eefc443bd763472b8ff2e9c2c0d54a5"
+  integrity sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==
+
 object-inspect@^1.12.0, object-inspect@^1.9.0:
   version "1.12.2"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.2.tgz#c0641f26394532f28ab8d796ab954e43c009a8ea"
@@ -3094,6 +3190,11 @@ prepend-http@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==
+
+property-expr@^2.0.4:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.5.tgz#278bdb15308ae16af3e3b9640024524f4dc02cb4"
+  integrity sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA==
 
 proxy-addr@~2.0.7:
   version "2.0.7"
@@ -3563,6 +3664,11 @@ toidentifier@1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
+toposort@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
+  integrity sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==
+
 touch@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/touch/-/touch-3.1.0.tgz#fe365f5f75ec9ed4e56825e0bb76d24ab74af83b"
@@ -3582,7 +3688,7 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
-tslib@^2.1.0, tslib@^2.4.0:
+tslib@^2.1.0, tslib@^2.4.0, tslib@~2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
@@ -3825,3 +3931,14 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+yup@^0.31.0:
+  version "0.31.1"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-0.31.1.tgz#0954cb181161f397b804346037a04f8a4b31599e"
+  integrity sha512-Lf6648jDYOWR75IlWkVfwesPyW6oj+50NpxlKvsQlpPsB8eI+ndI7b4S1VrwbmeV9hIZDu1MzrlIL4W+gK1jPw==
+  dependencies:
+    "@babel/runtime" "^7.10.5"
+    lodash "^4.17.20"
+    lodash-es "^4.17.11"
+    property-expr "^2.0.4"
+    toposort "^2.0.2"


### PR DESCRIPTION
## #61
This PR adds authorization on the backend using an auth middleware. Because of the auth middleware, a user must be logged in to `create`, `update`, or `delete` a journal. Further integration of users and journals was also added. Whenever a user creates a journal, that journal's `createdBy` field is populated by that user's Id.

### Changes

 - Added timestamps in journal schema. This handles `createdAt` and `updatedAt` fields automatically.
 - Added `logout` Mutation
 - Added authorization middleware
 - Added error handling in `createJournal` Mutation
 - Added error handling in `updateJournal` Mutation
 - Added boolean return type in `deleteJournal` Mutation
 - Integration of `user` and `journal` entities.
 
### Node Packages Added

[@graphql-tools/schema](https://www.npmjs.com/package/@graphql-tools/schema)
[graphql-middleware](https://www.npmjs.com/package/graphql-middleware)
[graphql-shield](https://www.npmjs.com/package/graphql-shield)