### PR TITLE
feat: role based auth

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import { applyMiddleware } from "graphql-middleware";
 import { authMiddleware } from "./middlewares/authMiddleware";
 import { makeExecutableSchema } from "@graphql-tools/schema";
 import { COOKIE_NAME } from "./constants";
+import { journalMiddleware } from "./middlewares/journalMiddleware";
 
 const startServer = async () => {
   const app = express();
@@ -59,7 +60,8 @@ const startServer = async () => {
   const server = new ApolloServer({
     schema: applyMiddleware(
       makeExecutableSchema({ typeDefs, resolvers }),
-      authMiddleware
+      authMiddleware,
+      journalMiddleware
     ),
     context: ({ req, res }) => ({ req, res, redis }),
   });

--- a/src/middlewares/authMiddleware.js
+++ b/src/middlewares/authMiddleware.js
@@ -1,13 +1,40 @@
-import { rule, shield } from "graphql-shield";
+import { rule, shield, and, or } from "graphql-shield";
+import { User } from "../models/User";
 
 const isAuthenticated = rule()((_, __, { req }) => {
   return !!req.session.userId;
 });
 
+const isAdmin = rule()(async (_, __, { req }) => {
+  const user = await User.findById(req.session.userId);
+  return user && user.role === "ADMIN";
+});
+
+const isModerator = rule()(async (_, __, { req }) => {
+  const user = await User.findById(req.session.userId);
+  return user && user.role === "MODERATOR";
+});
+
 export const authMiddleware = shield({
+  Query: {
+    // user queries
+    getCurrentUser: isAuthenticated,
+    getAllUsers: and(isAuthenticated, or(isAdmin, isModerator)),
+
+    // journal queries
+    getAllJournalsByUserId: isAuthenticated,
+    getAllJournalsByCurrentUser: isAuthenticated,
+  },
+
   Mutation: {
+    // user mutations
+    addMockUserData: and(isAuthenticated, isAdmin),
+    logout: isAuthenticated,
+
+    // journal mutations
+    addMockJournalData: and(isAuthenticated, isAdmin),
     createJournal: isAuthenticated,
-    updateJournal: isAuthenticated,
-    deleteJournal: isAuthenticated,
+    updateJournal: and(isAuthenticated, or(isAdmin, isModerator)),
+    deleteJournal: and(isAuthenticated, or(isAdmin, isModerator)),
   },
 });

--- a/src/middlewares/journalMiddleware.js
+++ b/src/middlewares/journalMiddleware.js
@@ -1,0 +1,28 @@
+import { Journal } from "../models/Journal";
+import { User } from "../models/User";
+
+export const journalMiddleware = {
+  Mutation: {
+    deleteJournal: async (resolve, parent, args, context, info) => {
+      try {
+        const journalToDelete = await Journal.findOne({
+          issn: args.issnToDelete,
+        });
+
+        await User.findByIdAndUpdate(
+          journalToDelete.createdBy,
+          {
+            $pull: {
+              journals: journalToDelete._id,
+            },
+          },
+          { safe: true }
+        );
+      } catch (error) {
+        console.log(error);
+      }
+
+      return resolve(parent, args, context, info);
+    },
+  },
+};

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -25,6 +25,13 @@ const userSchema = new Schema(
       required: true,
     },
 
+    role: {
+      type: String,
+      enum: ["USER", "ADMIN", "MODERATOR"],
+      required: true,
+      default: "USER",
+    },
+
     journals: [
       {
         type: Schema.Types.ObjectId,

--- a/src/resolvers/journalResolver.js
+++ b/src/resolvers/journalResolver.js
@@ -112,9 +112,9 @@ const journalResolver = {
         };
       }
 
-      const { _id } = journalToUpdate;
+      const { id } = journalToUpdate;
       try {
-        await Journal.updateOne({ _id }, { ...newJournalDetails });
+        await Journal.findByIdAndUpdate(id, { ...newJournalDetails });
       } catch (error) {
         if (error.code === 11000 && Object.keys(error.keyValue)[0] === "issn") {
           return {
@@ -128,7 +128,7 @@ const journalResolver = {
         }
       }
 
-      const updatedJournal = await Journal.findOne({ _id });
+      const updatedJournal = await Journal.findById(id);
       return { journal: updatedJournal };
     },
 

--- a/src/resolvers/userResolver.js
+++ b/src/resolvers/userResolver.js
@@ -7,6 +7,12 @@ import generateMockUsersArray from "../utils/generateUserData";
 const saltRounds = 12;
 
 const userResolver = {
+  Role: {
+    ADMIN: "ADMIN",
+    MODERATOR: "MODERATOR",
+    USER: "USER",
+  },
+
   Query: {
     getCurrentUser: async (_, _args, { req }) => {
       if (!req.session.userId) {

--- a/src/types/journalType.js
+++ b/src/types/journalType.js
@@ -39,7 +39,7 @@ const journalType = gql`
   }
 
   type Journal {
-    id: ID
+    id: ID!
     title: String!
     url: String!
     issn: String!
@@ -47,7 +47,7 @@ const journalType = gql`
     policies: Policies!
     createdAt: String!
     updatedAt: String!
-    createdBy: String!
+    createdBy: ID!
   }
 
   input JournalInput {

--- a/src/types/journalType.js
+++ b/src/types/journalType.js
@@ -70,7 +70,7 @@ const journalType = gql`
 
   type Query {
     getAllJournals(currentPageNumber: Int!, limitValue: Int!): [Journal]
-    getJournalByISSN(issn: Int): Journal
+    getJournalByISSN(issn: String!): Journal
     getAllJournalsByCurrentUser(
       currentPageNumber: Int!
       limitValue: Int!
@@ -84,7 +84,7 @@ const journalType = gql`
 
   type Mutation {
     createJournal(journalToCreate: JournalInput!): JournalResponse!
-    deleteJournal(issnToDelete: Int!): Boolean!
+    deleteJournal(issnToDelete: String!): Boolean!
     updateJournal(
       issnToUpdate: String!
       newJournalDetails: JournalInput!

--- a/src/types/journalType.js
+++ b/src/types/journalType.js
@@ -86,7 +86,7 @@ const journalType = gql`
     createJournal(journalToCreate: JournalInput!): JournalResponse!
     deleteJournal(issnToDelete: Int!): Boolean!
     updateJournal(
-      issnToUpdate: Int!
+      issnToUpdate: String!
       newJournalDetails: JournalInput!
     ): JournalResponse!
 

--- a/src/types/userType.js
+++ b/src/types/userType.js
@@ -1,11 +1,18 @@
 import { gql } from "apollo-server-express";
 
 const userType = gql`
+  enum Role {
+    ADMIN
+    MODERATOR
+    USER
+  }
+
   type User {
     id: ID
     fullName: String!
     username: String!
     email: String!
+    role: Role!
     createdAt: String!
     updatedAt: String!
   }

--- a/src/utils/generateUserData.js
+++ b/src/utils/generateUserData.js
@@ -6,6 +6,7 @@ const generateMockUser = () => {
     fullName: faker.fake("{{name.firstName}} {{name.lastName}}"),
     username: faker.internet.userName(),
     email: faker.internet.email(),
+    role: faker.helpers.arrayElement(["USER", "MODERATOR"]),
     password: faker.internet.password(),
     createdAt: faker.date.past(),
   };


### PR DESCRIPTION
## #66
This PR adds the functionality of role-based authorization to the user authentication system for the app.
There are 3 roles that can be assigned to a user with an account which are:
1. ADMIN
2. MODERATOR
3. USER

The capabilities of each role will be updated in the future as more and more functions are added to the app's backend.

### Other changes:
1. Adding a journal middleware. Now, while deleting a journal, that journal's reference will also get deleted from its creator's journals array. 
2. Type fixes in the journal data type file.