### PR TITLE
fix: pagination-fix

### DIFF
--- a/src/resolvers/journalResolver.js
+++ b/src/resolvers/journalResolver.js
@@ -33,13 +33,18 @@ const journalResolver = {
 
       const currentUser = await User.findById(req.session.userId);
 
+      const numberOfJournalsByCurrentUser = currentUser.journals.length;
+
       const allJournalsByCurrentUser = await Journal.find({
         _id: { $in: currentUser.journals },
       })
         .limit(limitValue)
         .skip(skipValue);
 
-      return allJournalsByCurrentUser;
+      return {
+        journals: allJournalsByCurrentUser,
+        totalJournals: numberOfJournalsByCurrentUser,
+      };
     },
 
     getAllJournalsByUserId: async (

--- a/src/resolvers/journalResolver.js
+++ b/src/resolvers/journalResolver.js
@@ -55,13 +55,18 @@ const journalResolver = {
 
       const user = await User.findById(userId);
 
-      const journals = await Journal.find({
+      const numberOfJournalsByUser = user.journals.length;
+
+      const allJournalsByUser = await Journal.find({
         _id: { $in: user.journals },
       })
         .limit(limitValue)
         .skip(skipValue);
 
-      return journals;
+      return {
+        journals: allJournalsByUser,
+        totalJournals: numberOfJournalsByUser,
+      };
     },
 
     getJournalByISSN: async (_, { issn }) => {

--- a/src/resolvers/journalResolver.js
+++ b/src/resolvers/journalResolver.js
@@ -19,7 +19,9 @@ const journalResolver = {
   Query: {
     getAllJournals: async (_, { currentPageNumber, limitValue }) => {
       const skipValue = (currentPageNumber - 1) * limitValue;
-      return await Journal.find().limit(limitValue).skip(skipValue);
+      const totalJournals = await Journal.count();
+      const journals = await Journal.find().limit(limitValue).skip(skipValue);
+      return { journals, totalJournals };
     },
 
     getAllJournalsByCurrentUser: async (

--- a/src/resolvers/userResolver.js
+++ b/src/resolvers/userResolver.js
@@ -23,7 +23,12 @@ const userResolver = {
     },
     getAllUsers: async (_, { currentPageNumber, limitValue }) => {
       const skipValue = (currentPageNumber - 1) * limitValue;
-      return await User.find().limit(limitValue).skip(skipValue);
+      const totalUsers = User.count();
+      const users = await User.find().limit(limitValue).skip(skipValue);
+      return {
+        users,
+        totalUsers,
+      };
     },
   },
 

--- a/src/types/journalType.js
+++ b/src/types/journalType.js
@@ -84,7 +84,7 @@ const journalType = gql`
       userId: ID!
       currentPageNumber: Int!
       limitValue: Int!
-    ): [Journal]
+    ): PaginatedJournals
   }
 
   type Mutation {

--- a/src/types/journalType.js
+++ b/src/types/journalType.js
@@ -59,8 +59,8 @@ const journalType = gql`
   }
 
   type PaginatedJournals {
-    journals: [Journal]
-    totalJournals: Int
+    journals: [Journal]!
+    totalJournals: Int!
   }
 
   type JournalResponse {
@@ -74,7 +74,10 @@ const journalType = gql`
   }
 
   type Query {
-    getAllJournals(currentPageNumber: Int!, limitValue: Int!): PaginatedJournals
+    getAllJournals(
+      currentPageNumber: Int!
+      limitValue: Int!
+    ): PaginatedJournals!
     getJournalByISSN(issn: String!): Journal
     getAllJournalsByCurrentUser(
       currentPageNumber: Int!

--- a/src/types/journalType.js
+++ b/src/types/journalType.js
@@ -79,7 +79,7 @@ const journalType = gql`
     getAllJournalsByCurrentUser(
       currentPageNumber: Int!
       limitValue: Int!
-    ): [Journal]
+    ): PaginatedJournals
     getAllJournalsByUserId(
       userId: ID!
       currentPageNumber: Int!

--- a/src/types/journalType.js
+++ b/src/types/journalType.js
@@ -58,6 +58,11 @@ const journalType = gql`
     policies: PoliciesInput!
   }
 
+  type PaginatedJournals {
+    journals: [Journal]
+    totalJournals: Int
+  }
+
   type JournalResponse {
     journal: Journal
     errors: [Error]
@@ -69,7 +74,7 @@ const journalType = gql`
   }
 
   type Query {
-    getAllJournals(currentPageNumber: Int!, limitValue: Int!): [Journal]
+    getAllJournals(currentPageNumber: Int!, limitValue: Int!): PaginatedJournals
     getJournalByISSN(issn: String!): Journal
     getAllJournalsByCurrentUser(
       currentPageNumber: Int!

--- a/src/types/userType.js
+++ b/src/types/userType.js
@@ -17,6 +17,11 @@ const userType = gql`
     updatedAt: String!
   }
 
+  type PaginatedUser {
+    users: [User]!
+    totalUsers: Int!
+  }
+
   input RegisterInput {
     fullName: String!
     username: String!
@@ -40,8 +45,8 @@ const userType = gql`
   }
 
   type Query {
-    getCurrentUser: User
-    getAllUsers(currentPageNumber: Int!, limitValue: Int!): [User]
+    getCurrentUser: User!
+    getAllUsers(currentPageNumber: Int!, limitValue: Int!): PaginatedUser!
   }
 
   type Mutation {


### PR DESCRIPTION
This PR fixes all the queries that returned items with pagination. Now with the paginated **user** / **journal** items, we also return the _**total number of users**_ and _**total numner of journals**_ with the response. Knowing the total number of items during pagination is important to calculate the last page of items on the front-end.