### PR TITLE
fix: add local env file to git

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,5 @@
+DATABASE_URL=mongodb://localhost:27017/dev
+PORT=4000
+SESSION_SECRET=asdilkhudfgaiosuvbiapsdi
+REDIS_URL=127.0.0.1:6379
+CORS_ORIGIN=http://localhost:3000

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
-.env
 .env.production
 dist


### PR DESCRIPTION
This will add the `.env` file to git. This file contains all the environment variables that are needed to run the project locally.
When the backend is pushed to `prod`, this file will be replaced with another `.env` file that contains all the appropirate environment variables for `prod` so we don't have to worry.