### PR TITLE
feat: adding forgot password feature to backend

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -2,37 +2,41 @@ name: Docker CI
 
 on:
   push:
-    branches: [ "dev" ]
+    branches: ["dev"]
   pull_request:
-    branches: [ "dev" ]
+    branches: ["dev"]
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: DockerHub Login
-      env:
-        DOCKER_USER: ${{ secrets.DOCKER_USER }}
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-      run: |
-        docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
-        
-    - name: Create production env file
-      env:
-        SESSION_SECRET: ${{ secrets.SESSION_SECRET }}
-      run : |
-        touch .env.production
-        echo CORS_ORIGIN=https://codeisscience.com >> .env.production
-        echo SESSION_SECRET=$SESSION_SECRET >> .env.production
-        
-    - name: Build the Docker Image
-      run: docker build -t codeisscience/journal-policy-tracker-backend:$(echo "$(date "+%Y%m%d%H%M") - ($(date +%M)%5)" | bc) .
+      - uses: actions/checkout@v3
+      - name: DockerHub Login
+        env:
+          DOCKER_USER: ${{ secrets.DOCKER_USER }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
 
-    - name: Push the Docker Image to DockerHub
-      run: docker push codeisscience/journal-policy-tracker-backend:$(echo "$(date "+%Y%m%d%H%M") - ($(date +%M)%5)" | bc)
+      - name: Create production env file
+        env:
+          SESSION_SECRET: ${{ secrets.SESSION_SECRET }}
+          REDIRECT_URI_GOOGLE: ${{ secrets.REDIRECT_URI_GOOGLE }}
+          REFRESH_TOKEN_GOOGLE: ${{ secrets.REFRESH_TOKEN_GOOGLE }}
+          CLIENT_ID_GOOGLE: ${{ secrets.CLIENT_ID_GOOGLE }}
+          CLIENT_SECRET_GOOGLE: ${{ secrets.CLIENT_SECRET_GOOGLE }}
+        run: |
+          touch .env.production
+          echo CORS_ORIGIN=https://codeisscience.com >> .env.production
+          echo SESSION_SECRET=$SESSION_SECRET >> .env.production
+          echo REDIRECT_URI_GOOGLE=$REDIRECT_URI_GOOGLE >> .env.production
+          echo REFRESH_TOKEN_GOOGLE=$REFRESH_TOKEN_GOOGLE >> .env.production
+          echo CLIENT_ID_GOOGLE=$CLIENT_ID_GOOGLE >> .env.production
+          echo CLIENT_SECRET_GOOGLE=$CLIENT_SECRET_GOOGLE >> .env.production
 
+      - name: Build the Docker Image
+        run: docker build -t codeisscience/journal-policy-tracker-backend:$(echo "$(date "+%Y%m%d%H%M") - ($(date +%M)%5)" | bc) .
 
+      - name: Push the Docker Image to DockerHub
+        run: docker push codeisscience/journal-policy-tracker-backend:$(echo "$(date "+%Y%m%d%H%M") - ($(date +%M)%5)" | bc)

--- a/package.json
+++ b/package.json
@@ -30,11 +30,14 @@
     "dotenv": "^16.0.1",
     "express": "^4.18.1",
     "express-session": "^1.17.3",
+    "googleapis": "^109.0.1",
     "graphql": "^16.5.0",
     "graphql-middleware": "^6.1.31",
     "graphql-shield": "^7.5.0",
     "ioredis": "^5.1.0",
     "mongoose": "^6.3.6",
+    "nodemailer": "^6.8.0",
+    "uuid": "^9.0.0",
     "validator": "^13.7.0"
   },
   "devDependencies": {

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,2 +1,8 @@
 export const COOKIE_NAME = "obfc";
 export const __prod__ = process.env.NODE_ENV === "production";
+export const FORGET_PASSWORD_PREFIX = "forget-password:";
+export const LOGO_URL =
+  "https://codeisscience-community.netlify.app/img/brand.png";
+export const CENTER_IMAGE_URL =
+  "https://user-images.githubusercontent.com/59534570/205953467-e60d4683-ea80-40c0-9aa2-b885663de0d3.png";
+export const CODE_IS_SCIENCE_URL = "https://codeisscience.com";

--- a/src/types/userType.js
+++ b/src/types/userType.js
@@ -53,6 +53,8 @@ const userType = gql`
   type Mutation {
     register(userInfo: RegisterInput!): UserResponse!
     login(userInfo: LoginInput!): UserResponse!
+    forgotPassword(email: String!): Boolean!
+    changeForgotPassword(token: String!, newPassword: String!): UserResponse!
     logout: Boolean!
     addMockUserData(numberOfUsers: Int!): Boolean!
   }

--- a/src/utils/forgotPasswordEmailTemplate.js
+++ b/src/utils/forgotPasswordEmailTemplate.js
@@ -1,7 +1,7 @@
 const forgotPasswordEmailTemplate = (
   forgotPasswordURL,
   logoURL,
-  displayImageURL,
+  centerImageURL,
   codeIsScienceURL
 ) => {
   return `
@@ -424,7 +424,7 @@ text-decoration: none; height: auto; width: 200px; height: auto; margin: 0px;" w
  exactly; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; color:
  #f84b4b; font-weight: normal; text-decoration: none" target="_blank" title="">
 																		<img align="center" alt="Forgot your password?" class="mcnImage"
-																			src="${displayImageURL}"
+																			src="${centerImageURL}"
 																			style="-ms-interpolation-mode: bicubic; border: 0; height: auto; outline: none;
  text-decoration: none; vertical-align: bottom; max-width:1200px; padding-bottom:
  0; display: inline !important; vertical-align: bottom;" width="600"></img>

--- a/src/utils/forgotPasswordEmailTemplate.js
+++ b/src/utils/forgotPasswordEmailTemplate.js
@@ -1,0 +1,646 @@
+const forgotPasswordEmailTemplate = (
+  forgotPasswordURL,
+  logoURL,
+  displayImageURL,
+  codeIsScienceURL
+) => {
+  return `
+		<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml"
+	xmlns:o="urn:schemas-microsoft-com:office:office">
+
+<head>
+
+	<meta charset="UTF-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>Reset Your Password</title>
+
+	<link href='https://fonts.googleapis.com/css?family=Asap:400,400italic,700,700italic' rel='stylesheet'
+		type='text/css'>
+
+	<style type="text/css">
+		@media only screen and (min-width:768px) {
+			.templateContainer {
+				width: 600px !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+
+			body,
+			table,
+			td,
+			p,
+			a,
+			li,
+			blockquote {
+				-webkit-text-size-adjust: none !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+			body {
+				width: 100% !important;
+				min-width: 100% !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+			#bodyCell {
+				padding-top: 10px !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+			.mcnImage {
+				width: 100% !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+
+			.mcnCaptionTopContent,
+			.mcnCaptionBottomContent,
+			.mcnTextContentContainer,
+			.mcnBoxedTextContentContainer,
+			.mcnImageGroupContentContainer,
+			.mcnCaptionLeftTextContentContainer,
+			.mcnCaptionRightTextContentContainer,
+			.mcnCaptionLeftImageContentContainer,
+			.mcnCaptionRightImageContentContainer,
+			.mcnImageCardLeftTextContentContainer,
+			.mcnImageCardRightTextContentContainer {
+				max-width: 100% !important;
+				width: 100% !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+			.mcnBoxedTextContentContainer {
+				min-width: 100% !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+			.mcnImageGroupContent {
+				padding: 9px !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+
+			.mcnCaptionLeftContentOuter .mcnTextContent,
+			.mcnCaptionRightContentOuter .mcnTextContent {
+				padding-top: 9px !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+
+			.mcnImageCardTopImageContent,
+			.mcnCaptionBlockInner .mcnCaptionTopContent:last-child .mcnTextContent {
+				padding-top: 18px !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+			.mcnImageCardBottomImageContent {
+				padding-bottom: 9px !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+			.mcnImageGroupBlockInner {
+				padding-top: 0 !important;
+				padding-bottom: 0 !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+			.mcnImageGroupBlockOuter {
+				padding-top: 9px !important;
+				padding-bottom: 9px !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+
+			.mcnTextContent,
+			.mcnBoxedTextContentColumn {
+				padding-right: 18px !important;
+				padding-left: 18px !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+
+			.mcnImageCardLeftImageContent,
+			.mcnImageCardRightImageContent {
+				padding-right: 18px !important;
+				padding-bottom: 0 !important;
+				padding-left: 18px !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+			.mcpreview-image-uploader {
+				display: none !important;
+				width: 100% !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+
+			/*
+      @tab Mobile Styles
+      @section Heading 1
+      @tip Make the first-level headings larger in size for better readability
+   on small screens.
+      */
+			h1 {
+				/*@editable*/
+				font-size: 20px !important;
+				/*@editable*/
+				line-height: 150% !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+
+			/*
+      @tab Mobile Styles
+      @section Heading 2
+      @tip Make the second-level headings larger in size for better
+   readability on small screens.
+      */
+			h2 {
+				/*@editable*/
+				font-size: 20px !important;
+				/*@editable*/
+				line-height: 150% !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+
+			/*
+      @tab Mobile Styles
+      @section Heading 3
+      @tip Make the third-level headings larger in size for better readability
+   on small screens.
+      */
+			h3 {
+				/*@editable*/
+				font-size: 18px !important;
+				/*@editable*/
+				line-height: 150% !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+
+			/*
+      @tab Mobile Styles
+      @section Heading 4
+      @tip Make the fourth-level headings larger in size for better
+   readability on small screens.
+      */
+			h4 {
+				/*@editable*/
+				font-size: 16px !important;
+				/*@editable*/
+				line-height: 150% !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+
+			/*
+      @tab Mobile Styles
+      @section Boxed Text
+      @tip Make the boxed text larger in size for better readability on small
+   screens. We recommend a font size of at least 16px.
+      */
+			.mcnBoxedTextContentContainer .mcnTextContent,
+			.mcnBoxedTextContentContainer .mcnTextContent p {
+				/*@editable*/
+				font-size: 16px !important;
+				/*@editable*/
+				line-height: 150% !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+
+			/*
+      @tab Mobile Styles
+      @section Preheader Visibility
+      @tip Set the visibility of the email's preheader on small screens. You
+   can hide it to save space.
+      */
+			#templatePreheader {
+				/*@editable*/
+				display: block !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+
+			/*
+      @tab Mobile Styles
+      @section Preheader Text
+      @tip Make the preheader text larger in size for better readability on
+   small screens.
+      */
+			#templatePreheader .mcnTextContent,
+			#templatePreheader .mcnTextContent p {
+				/*@editable*/
+				font-size: 12px !important;
+				/*@editable*/
+				line-height: 150% !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+
+			/*
+      @tab Mobile Styles
+      @section Header Text
+      @tip Make the header text larger in size for better readability on small
+   screens.
+      */
+			#templateHeader .mcnTextContent,
+			#templateHeader .mcnTextContent p {
+				/*@editable*/
+				font-size: 16px !important;
+				/*@editable*/
+				line-height: 150% !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+
+			/*
+      @tab Mobile Styles
+      @section Body Text
+      @tip Make the body text larger in size for better readability on small
+   screens. We recommend a font size of at least 16px.
+      */
+			#templateBody .mcnTextContent,
+			#templateBody .mcnTextContent p {
+				/*@editable*/
+				font-size: 16px !important;
+				/*@editable*/
+				line-height: 150% !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+
+			/*
+      @tab Mobile Styles
+      @section Footer Text
+      @tip Make the footer content text larger in size for better readability
+   on small screens.
+      */
+			#templateFooter .mcnTextContent,
+			#templateFooter .mcnTextContent p {
+				/*@editable*/
+				font-size: 12px !important;
+				/*@editable*/
+				line-height: 150% !important;
+			}
+
+		}
+	</style>
+</head>
+
+<body style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;
+ background-color: #e8ebed; height: 100%; margin: 0; padding: 0; width: 100%">
+	<center>
+		<table align="center" border="0" cellpadding="0" cellspacing="0" height="100%" id="bodyTable" style="border-collapse: collapse; mso-table-lspace: 0;
+ mso-table-rspace: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust:
+ 100%; background-color: #e8ebed; height: 100%; margin: 0; padding: 0; width:
+ 100%" width="100%">
+			<tr>
+				<td align="center" id="bodyCell" style="mso-line-height-rule: exactly;
+ -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; border-top: 0;
+ height: 100%; margin: 0; padding: 0; width: 100%" valign="top">
+					<!-- BEGIN TEMPLATE // -->
+					<table border="0" cellpadding="0" cellspacing="0" class="templateContainer" style="border-collapse: collapse; mso-table-lspace: 0; mso-table-rspace: 0;
+ -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; max-width:
+ 600px; border: 0" width="100%">
+						<tr>
+							<td id="templatePreheader" style="mso-line-height-rule: exactly;
+ -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #e8ebed;
+ border-top: 0; border-bottom: 0; padding-top: 16px; padding-bottom: 8px" valign="top">
+								<table border="0" cellpadding="0" cellspacing="0" class="mcnTextBlock" style="border-collapse: collapse; mso-table-lspace: 0;
+ mso-table-rspace: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;
+ min-width:100%;" width="100%">
+									<tbody class="mcnTextBlockOuter">
+										<tr>
+											<td class="mcnTextBlockInner" style="mso-line-height-rule: exactly;
+ -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%" valign="top">
+												<table align="left" border="0" cellpadding="0" cellspacing="0" class="mcnTextContentContainer"
+													style="border-collapse: collapse; mso-table-lspace: 0;
+ mso-table-rspace: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust:
+ 100%; min-width:100%;" width="100%">
+													<tbody>
+														<tr>
+															<td class="mcnTextContent" style='mso-line-height-rule: exactly;
+ -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; word-break: break-word;
+ color: #2a2a2a; font-family: "Asap", Helvetica, sans-serif; font-size: 12px;
+ line-height: 150%; text-align: left; padding-top:9px; padding-right: 18px;
+ padding-bottom: 9px; padding-left: 18px;' valign="top">
+																<a href="${codeIsScienceURL}" style="mso-line-height-rule: exactly;
+ -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; color: #2a2a2a;
+ font-weight: normal; text-decoration: none" target="_blank"
+																	title="CodeIsScience helps researchers find policy details for journal.">
+																	<img align="none"
+																		alt="CodeIsScience helps researchers find policy details for journal." height="48"
+																		src="${logoURL}" style="-ms-interpolation-mode: bicubic; border: 0; outline: none;
+text-decoration: none; height: auto; width: 200px; height: auto; margin: 0px;" width="126" />
+																</a>
+															</td>
+														</tr>
+													</tbody>
+												</table>
+											</td>
+										</tr>
+									</tbody>
+								</table>
+							</td>
+						</tr>
+						<tr>
+							<td id="templateHeader" style="mso-line-height-rule: exactly;
+ -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #ffffff;
+ border-top: 0; border-bottom: 0; padding-top: 16px; padding-bottom: 0" valign="top">
+								<table border="0" cellpadding="0" cellspacing="0" class="mcnImageBlock" style="border-collapse: collapse; mso-table-lspace: 0; mso-table-rspace: 0;
+ -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;
+ min-width:100%;" width="100%">
+									<tbody class="mcnImageBlockOuter">
+										<tr>
+											<td class="mcnImageBlockInner" style="mso-line-height-rule: exactly;
+ -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; padding:0px" valign="top">
+												<table align="left" border="0" cellpadding="0" cellspacing="0" class="mcnImageContentContainer"
+													style="border-collapse: collapse; mso-table-lspace: 0;
+ mso-table-rspace: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust:
+ 100%; min-width:100%;" width="100%">
+													<tbody>
+														<tr>
+															<td class="mcnImageContent" style="mso-line-height-rule: exactly;
+ -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; padding-right: 0px;
+ padding-left: 0px; padding-top: 0; padding-bottom: 0; text-align:center;" valign="top">
+																<a class="" href="${codeIsScienceURL}" style="mso-line-height-rule:
+ exactly; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; color:
+ #f84b4b; font-weight: normal; text-decoration: none" target="_blank" title="">
+																	<a class="" href="${codeIsScienceURL}" style="mso-line-height-rule:
+ exactly; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; color:
+ #f84b4b; font-weight: normal; text-decoration: none" target="_blank" title="">
+																		<img align="center" alt="Forgot your password?" class="mcnImage"
+																			src="${displayImageURL}"
+																			style="-ms-interpolation-mode: bicubic; border: 0; height: auto; outline: none;
+ text-decoration: none; vertical-align: bottom; max-width:1200px; padding-bottom:
+ 0; display: inline !important; vertical-align: bottom;" width="600"></img>
+																	</a>
+																</a>
+															</td>
+														</tr>
+													</tbody>
+												</table>
+											</td>
+										</tr>
+									</tbody>
+								</table>
+							</td>
+						</tr>
+						<tr>
+							<td id="templateBody" style="mso-line-height-rule: exactly;
+ -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #ffffff;
+ border-top: 0; border-bottom: 0; padding-top: 0; padding-bottom: 0" valign="top">
+								<table border="0" cellpadding="0" cellspacing="0" class="mcnTextBlock" style="border-collapse: collapse; mso-table-lspace: 0; mso-table-rspace: 0;
+ -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; min-width:100%;" width="100%">
+									<tbody class="mcnTextBlockOuter">
+										<tr>
+											<td class="mcnTextBlockInner" style="mso-line-height-rule: exactly;
+ -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%" valign="top">
+												<table align="left" border="0" cellpadding="0" cellspacing="0" class="mcnTextContentContainer"
+													style="border-collapse: collapse; mso-table-lspace: 0;
+ mso-table-rspace: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust:
+ 100%; min-width:100%;" width="100%">
+													<tbody>
+														<tr>
+															<td class="mcnTextContent" style='mso-line-height-rule: exactly;
+ -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; word-break: break-word;
+ color: #2a2a2a; font-family: "Asap", Helvetica, sans-serif; font-size: 16px;
+ line-height: 150%; text-align: center; padding-top:9px; padding-right: 18px;
+ padding-bottom: 9px; padding-left: 18px;' valign="top">
+
+																<h1 class="null" style='color: #2a2a2a; font-family: "Asap", Helvetica,
+ sans-serif; font-size: 32px; font-style: normal; font-weight: bold; line-height:
+ 125%; letter-spacing: 2px; text-align: center; display: block; margin: 0;
+ padding: 0'><span style="text-transform:uppercase">Forgot</span></h1>
+
+
+																<h2 class="null" style='color: #2a2a2a; font-family: "Asap", Helvetica,
+ sans-serif; font-size: 24px; font-style: normal; font-weight: bold; line-height:
+ 125%; letter-spacing: 1px; text-align: center; display: block; margin: 0;
+ padding: 0'><span style="text-transform:uppercase">your password?</span></h2>
+
+															</td>
+														</tr>
+													</tbody>
+												</table>
+											</td>
+										</tr>
+									</tbody>
+								</table>
+								<table border="0" cellpadding="0" cellspacing="0" class="mcnTextBlock" style="border-collapse: collapse; mso-table-lspace: 0; mso-table-rspace:
+ 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;
+ min-width:100%;" width="100%">
+									<tbody class="mcnTextBlockOuter">
+										<tr>
+											<td class="mcnTextBlockInner" style="mso-line-height-rule: exactly;
+ -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%" valign="top">
+												<table align="left" border="0" cellpadding="0" cellspacing="0" class="mcnTextContentContainer"
+													style="border-collapse: collapse; mso-table-lspace: 0;
+ mso-table-rspace: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust:
+ 100%; min-width:100%;" width="100%">
+													<tbody>
+														<tr>
+															<td class="mcnTextContent" style='mso-line-height-rule: exactly;
+ -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; word-break: break-word;
+ color: #2a2a2a; font-family: "Asap", Helvetica, sans-serif; font-size: 16px;
+ line-height: 150%; text-align: center; padding-top:9px; padding-right: 18px;
+ padding-bottom: 9px; padding-left: 18px;' valign="top">Not to worry, we got you! Let’s get you a new password.
+																<br></br>
+															</td>
+														</tr>
+													</tbody>
+												</table>
+											</td>
+										</tr>
+									</tbody>
+								</table>
+								<table border="0" cellpadding="0" cellspacing="0" class="mcnButtonBlock" style="border-collapse: collapse; mso-table-lspace: 0;
+ mso-table-rspace: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;
+ min-width:100%;" width="100%">
+									<tbody class="mcnButtonBlockOuter">
+										<tr>
+											<td align="center" class="mcnButtonBlockInner" style="mso-line-height-rule:
+ exactly; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;
+ padding-top:18px; padding-right:18px; padding-bottom:18px; padding-left:18px;" valign="top">
+												<table border="0" cellpadding="0" cellspacing="0" class="mcnButtonBlock" style="border-collapse: collapse; mso-table-lspace: 0; mso-table-rspace: 0;
+ -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; min-width:100%;" width="100%">
+													<tbody class="mcnButtonBlockOuter">
+														<tr>
+															<td align="center" class="mcnButtonBlockInner" style="mso-line-height-rule:
+ exactly; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;
+ padding-top:0; padding-right:18px; padding-bottom:18px; padding-left:18px;" valign="top">
+																<table border="0" cellpadding="0" cellspacing="0" class="mcnButtonContentContainer"
+																	style="border-collapse: collapse; mso-table-lspace: 0;
+ mso-table-rspace: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;
+ border-collapse: separate !important;border-radius: 48px;background-color:
+ #f84b4b;">
+																	<tbody>
+																		<tr>
+																			<td align="center" class="mcnButtonContent" style="mso-line-height-rule:
+ exactly; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;
+ font-family: 'Asap', Helvetica, sans-serif; font-size: 16px; padding-top:24px;
+ padding-right:48px; padding-bottom:24px; padding-left:48px;" valign="middle">
+																				<a class="mcnButton " href="${forgotPasswordURL}" style="mso-line-height-rule: exactly;
+ -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; display: block; color: #f84b4b;
+ font-weight: normal; text-decoration: none; font-weight: normal;letter-spacing:
+ 1px;line-height: 100%;text-align: center;text-decoration: none;color:
+ #FFFFFF; text-transform:uppercase;" target="_blank" title="Reset your CodeIsScience password">Reset password</a>
+																			</td>
+																		</tr>
+																	</tbody>
+																</table>
+															</td>
+														</tr>
+													</tbody>
+												</table>
+											</td>
+										</tr>
+									</tbody>
+								</table>
+								<table border="0" cellpadding="0" cellspacing="0" class="mcnImageBlock" style="border-collapse: collapse; mso-table-lspace: 0; mso-table-rspace: 0;
+ -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; min-width:100%;" width="100%">
+									<tbody class="mcnImageBlockOuter">
+										<tr>
+											<td class="mcnImageBlockInner" style="mso-line-height-rule: exactly;
+ -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; padding:0px" valign="top">
+												<table align="left" border="0" cellpadding="0" cellspacing="0" class="mcnImageContentContainer"
+													style="border-collapse: collapse; mso-table-lspace: 0;
+ mso-table-rspace: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust:
+ 100%; min-width:100%;" width="100%">
+													<tbody>
+														<tr>
+															<td class="mcnImageContent" style="mso-line-height-rule: exactly;
+ -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; padding-right: 0px;
+ padding-left: 0px; padding-top: 0; padding-bottom: 0; text-align:center;" valign="top"></td>
+														</tr>
+													</tbody>
+												</table>
+											</td>
+										</tr>
+									</tbody>
+								</table>
+							</td>
+						</tr>
+						<tr>
+							<td id="templateFooter" style="mso-line-height-rule: exactly;
+ -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #e8ebed;
+ border-top: 0; border-bottom: 0; padding-top: 8px; padding-bottom: 80px" valign="top">
+								<table border="0" cellpadding="0" cellspacing="0" class="mcnTextBlock" style="border-collapse: collapse; mso-table-lspace: 0; mso-table-rspace: 0;
+ -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; min-width:100%;" width="100%">
+									<tbody class="mcnTextBlockOuter">
+										<tr>
+											<td class="mcnTextBlockInner" style="mso-line-height-rule: exactly;
+ -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%" valign="top">
+												<table align="center" bgcolor="#ffffff" border="0" cellpadding="32" cellspacing="0" class="card"
+													style="border-collapse: collapse; mso-table-lspace: 0;
+ mso-table-rspace: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust:
+ 100%; background:#ffffff; margin:auto; text-align:left; max-width:600px;
+ font-family: 'Asap', Helvetica, sans-serif;" text-align="left" width="100%">
+													<tr>
+														<td style="mso-line-height-rule: exactly; -ms-text-size-adjust: 100%;
+ -webkit-text-size-adjust: 100%">
+
+															<h3 style='color: #3e434a; font-family: "Asap", Helvetica, sans-serif;
+ font-size: 20px; font-style: normal; font-weight: normal; line-height: 125%;
+ letter-spacing: normal; text-align: center; display: block; margin: 0; padding:
+ 0; text-align: left; width: 100%; font-size: 16px; font-weight: bold; '>What is CodeIsScience?</h3>
+
+															<p style='margin: 10px 0; padding: 0; mso-line-height-rule: exactly;
+ -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; color: #2a2a2a;
+ font-family: "Asap", Helvetica, sans-serif; font-size: 12px; line-height: 150%;
+ text-align: left; text-align: left; font-size: 14px; '>
+																CodeIsScience helps researchers find policy details for journal.
+															</p>
+															<div style="padding-bottom: 18px;">
+																<a href="${codeIsScienceURL}" style="mso-line-height-rule: exactly; -ms-text-size-adjust: 100%;
+ -webkit-text-size-adjust: 100%; color: #f84b4b; font-weight: normal; text-decoration: none;
+ font-size: 14px; color:#f84b4b; text-decoration:none;" target="_blank" title="Learn more about CodeIsScience">Learn
+																	More ❯</a>
+															</div>
+														</td>
+													</tr>
+												</table>
+												<table align="center" border="0" cellpadding="0" cellspacing="0" style="border-collapse: collapse; mso-table-lspace: 0; mso-table-rspace: 0;
+ -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; min-width:100%;" width="100%">
+
+												</table>
+												<table align="center" border="0" cellpadding="12" style="border-collapse:
+ collapse; mso-table-lspace: 0; mso-table-rspace: 0; -ms-text-size-adjust:
+ 100%; -webkit-text-size-adjust: 100%; ">
+													<tbody>
+
+													</tbody>
+												</table>
+											</td>
+										</tr>
+									</tbody>
+								</table>
+							</td>
+						</tr>
+					</table>
+
+				</td>
+			</tr>
+		</table>
+	</center>
+</body>
+
+</html>
+	`;
+};
+
+export default forgotPasswordEmailTemplate;

--- a/src/utils/sendEmail.js
+++ b/src/utils/sendEmail.js
@@ -1,0 +1,50 @@
+"use strict";
+import { createTransport } from "nodemailer";
+import { google } from "googleapis";
+import "dotenv/config";
+
+const CLIENT_ID = process.env.CLIENT_ID_GOOGLE;
+const CLIENT_SECRET = process.env.CLIENT_SECRET_GOOGLE;
+const REDIRECT_URI = process.env.REDIRECT_URI_GOOGLE;
+const REFRESH_TOKEN = process.env.REFRESH_TOKEN_GOOGLE;
+
+const oAuth2Client = new google.auth.OAuth2(
+  CLIENT_ID,
+  CLIENT_SECRET,
+  REDIRECT_URI
+);
+oAuth2Client.setCredentials({ refresh_token: REFRESH_TOKEN });
+
+export async function sendEmail(to, subject, html) {
+  try {
+    const accessToken = await oAuth2Client.getAccessToken();
+
+    const transport = createTransport({
+      service: "gmail",
+      auth: {
+        type: "OAuth2",
+        user: "codeisscience@gmail.com",
+        clientId: CLIENT_ID,
+        clientSecret: CLIENT_SECRET,
+        refreshToken: REFRESH_TOKEN,
+        accessToken: accessToken,
+      },
+    });
+
+    const mailOptions = {
+      from: "Code Is Science <codeisscience@gmail.com>",
+      to,
+      subject,
+      html,
+    };
+
+    const emailInfo = await transport.sendMail(mailOptions);
+
+    // console.log("Message sent: %s", emailInfo.messageId);
+    // console.log("Preview URL: %s", getTestMessageUrl(emailInfo));
+
+    return emailInfo;
+  } catch (error) {
+    return error;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2114,6 +2114,11 @@ array.prototype.reduce@^1.0.4:
     es-array-method-boxes-properly "^1.0.0"
     is-string "^1.0.7"
 
+arrify@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
+  integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
+
 async-retry@^1.2.1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.3.3.tgz#0e7f36c04d8478e7a58bdbed80cedf977785f280"
@@ -2217,7 +2222,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base64-js@^1.3.1:
+base64-js@^1.3.0, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -2229,6 +2234,11 @@ bcrypt@^5.0.1:
   dependencies:
     "@mapbox/node-pre-gyp" "^1.0.0"
     node-addon-api "^3.1.0"
+
+bignumber.js@^9.0.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.0.tgz#8d340146107fe3a6cb8d40699643c302e8773b62"
+  integrity sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==
 
 binary-extensions@^2.0.0:
   version "2.2.0"
@@ -2306,6 +2316,11 @@ bson@^4.6.2:
   integrity sha512-TdQ3FzguAu5HKPPlr0kYQCyrYUYh8tFM+CMTpxjNzVzxeiJY00Rtuj3LXLHSgiGvmaWlZ8PE+4KyM2thqE38pQ==
   dependencies:
     buffer "^5.6.0"
+
+buffer-equal-constant-time@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==
 
 buffer-from@^1.0.0:
   version "1.1.2"
@@ -2726,6 +2741,13 @@ duplexer3@^0.1.4:
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
   integrity sha512-CEj8FwwNA4cVH2uFCoHUrmojhYh1vmCdOaneKJXwkeY1i9jnlslVo9dx+hQ5Hl9GnH/Bwy/IjxAyOePyPKYnzA==
 
+ecdsa-sig-formatter@1.0.11, ecdsa-sig-formatter@^1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
+  dependencies:
+    safe-buffer "^5.0.1"
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -2941,10 +2963,20 @@ express@^4.18.1:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
+extend@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+
 fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
+
+fast-text-encoding@^1.0.0:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz#0aa25f7f638222e3396d72bf936afcf1d42d6867"
+  integrity sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==
 
 fb-watchman@^2.0.0:
   version "2.0.1"
@@ -3064,6 +3096,24 @@ gauge@^3.0.0:
     strip-ansi "^6.0.1"
     wide-align "^1.1.2"
 
+gaxios@^5.0.0, gaxios@^5.0.1:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/gaxios/-/gaxios-5.0.2.tgz#ca3a40e851c728d31d7001c2357062d46bf966d1"
+  integrity sha512-TjtV2AJOZoMQqRYoy5eM8cCQogYwazWNYLQ72QB0kwa6vHHruYkGmhhyrlzbmgNHK1dNnuP2WSH81urfzyN2Og==
+  dependencies:
+    extend "^3.0.2"
+    https-proxy-agent "^5.0.0"
+    is-stream "^2.0.0"
+    node-fetch "^2.6.7"
+
+gcp-metadata@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-5.0.1.tgz#8d1e785ee7fad554bc2a80c1f930c9a9518d2b00"
+  integrity sha512-jiRJ+Fk7e8FH68Z6TLaqwea307OktJpDjmYnU7/li6ziwvVvU2RlrCyQo5vkdeP94chm0kcSCOOszvmuaioq3g==
+  dependencies:
+    gaxios "^5.0.0"
+    json-bigint "^1.0.0"
+
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
@@ -3146,6 +3196,48 @@ globals@^11.1.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
+google-auth-library@^8.0.2:
+  version "8.7.0"
+  resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-8.7.0.tgz#e36e255baba4755ce38dded4c50f896cf8515e51"
+  integrity sha512-1M0NG5VDIvJZEnstHbRdckLZESoJwguinwN8Dhae0j2ZKIQFIV63zxm6Fo6nM4xkgqUr2bbMtV5Dgo+Hy6oo0Q==
+  dependencies:
+    arrify "^2.0.0"
+    base64-js "^1.3.0"
+    ecdsa-sig-formatter "^1.0.11"
+    fast-text-encoding "^1.0.0"
+    gaxios "^5.0.0"
+    gcp-metadata "^5.0.0"
+    gtoken "^6.1.0"
+    jws "^4.0.0"
+    lru-cache "^6.0.0"
+
+google-p12-pem@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/google-p12-pem/-/google-p12-pem-4.0.1.tgz#82841798253c65b7dc2a4e5fe9df141db670172a"
+  integrity sha512-WPkN4yGtz05WZ5EhtlxNDWPhC4JIic6G8ePitwUWy4l+XPVYec+a0j0Ts47PDtW59y3RwAhUd9/h9ZZ63px6RQ==
+  dependencies:
+    node-forge "^1.3.1"
+
+googleapis-common@^6.0.0:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/googleapis-common/-/googleapis-common-6.0.3.tgz#c11cdef91b272a13eb689b143f83a038fb2c403d"
+  integrity sha512-Xyb4FsQ6PQDu4tAE/M/ev4yzZhFe2Gc7+rKmuCX2ZGk1ajBKbafsGlVYpmzGqQOT93BRDe8DiTmQb6YSkbICrA==
+  dependencies:
+    extend "^3.0.2"
+    gaxios "^5.0.1"
+    google-auth-library "^8.0.2"
+    qs "^6.7.0"
+    url-template "^2.0.8"
+    uuid "^9.0.0"
+
+googleapis@^109.0.1:
+  version "109.0.1"
+  resolved "https://registry.yarnpkg.com/googleapis/-/googleapis-109.0.1.tgz#e4b160c9aff12acfd8ce0b4617f5192b7b8c01b3"
+  integrity sha512-x286OtNu0ngzxfGz2XgRs4aMhrwutRCkCE12dh2M1jIZOpOndB7ELFXEhmtxaJ7z3257flKIbiiCJZeBO+ze/Q==
+  dependencies:
+    google-auth-library "^8.0.2"
+    googleapis-common "^6.0.0"
+
 got@^9.6.0:
   version "9.6.0"
   resolved "https://registry.yarnpkg.com/got/-/got-9.6.0.tgz#edf45e7d67f99545705de1f7bbeeeb121765ed85"
@@ -3196,6 +3288,15 @@ graphql@^16.5.0:
   version "16.5.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.5.0.tgz#41b5c1182eaac7f3d47164fb247f61e4dfb69c85"
   integrity sha512-qbHgh8Ix+j/qY+a/ZcJnFQ+j8ezakqPiHwPiZhV/3PgGlgf96QMBB5/f2rkiC9sgLoy/xvT6TSiaf2nTHJh5iA==
+
+gtoken@^6.1.0:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/gtoken/-/gtoken-6.1.2.tgz#aeb7bdb019ff4c3ba3ac100bbe7b6e74dce0e8bc"
+  integrity sha512-4ccGpzz7YAr7lxrT2neugmXQ3hP9ho2gcaityLVkiUecAiwiy60Ii8gRbZeOsXV19fYaRjgBSshs8kXw+NKCPQ==
+  dependencies:
+    gaxios "^5.0.1"
+    google-p12-pem "^4.0.0"
+    jws "^4.0.0"
 
 has-bigints@^1.0.1, has-bigints@^1.0.2:
   version "1.0.2"
@@ -4042,6 +4143,13 @@ jsesc@~0.5.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
   integrity sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==
 
+json-bigint@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-bigint/-/json-bigint-1.0.0.tgz#ae547823ac0cad8398667f8cd9ef4730f5b01ff1"
+  integrity sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==
+  dependencies:
+    bignumber.js "^9.0.0"
+
 json-buffer@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
@@ -4056,6 +4164,23 @@ json5@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
   integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
+
+jwa@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-2.0.0.tgz#a7e9c3f29dae94027ebcaf49975c9345593410fc"
+  integrity sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==
+  dependencies:
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jws@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-4.0.0.tgz#2d4e8cf6a318ffaa12615e9dec7e86e6c97310f4"
+  integrity sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==
+  dependencies:
+    jwa "^2.0.0"
+    safe-buffer "^5.0.1"
 
 kareem@2.3.5:
   version "2.3.5"
@@ -4372,6 +4497,11 @@ node-fetch@^2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
+node-forge@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
+  integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -4381,6 +4511,11 @@ node-releases@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.5.tgz#280ed5bc3eba0d96ce44897d8aee478bfb3d9666"
   integrity sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q==
+
+nodemailer@^6.8.0:
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.8.0.tgz#804bcc5256ee5523bc914506ee59f8de8f0b1cd5"
+  integrity sha512-EjYvSmHzekz6VNkNd12aUqAco+bOkRe3Of5jVhltqKhEsjw/y0PYPJfp83+s9Wzh1dspYAkUW/YNQ350NATbSQ==
 
 nodemon@^2.0.16:
   version "2.0.16"
@@ -4710,6 +4845,13 @@ qs@6.10.3:
   version "6.10.3"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.3.tgz#d6cde1b2ffca87b5aa57889816c5f81535e22e8e"
   integrity sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==
+  dependencies:
+    side-channel "^1.0.4"
+
+qs@^6.7.0:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
+  integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
   dependencies:
     side-channel "^1.0.4"
 
@@ -5422,6 +5564,11 @@ url-parse-lax@^3.0.0:
   dependencies:
     prepend-http "^2.0.0"
 
+url-template@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/url-template/-/url-template-2.0.8.tgz#fc565a3cccbff7730c775f5641f9555791439f21"
+  integrity sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==
+
 util-deprecate@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
@@ -5436,6 +5583,11 @@ uuid@^8.0.0:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 v8-to-istanbul@^9.0.1:
   version "9.0.1"


### PR DESCRIPTION
## #76

This PR adds the feature of resetting the password for a user account in case the user forgets it.

The procedure to reset the password will be the following:
1. User clicks on forgot-password link on the register/login page.
2. The forgot-password page asks the user the email address which was used while registering the account.
3. The user enters that email address and clicks the submit button.
4. If such an email address exists in the database, a forgot-password email will be sent to that email address.
5. The user will click the `RESET PASSWORD` button on that email.
6. That will take the user to a reset password page where a new password can be set for that account.

### Changes
 - Added a forgot-password email template that will go to the user's email.
 - Added `forgotPassword` Mutation
 - Added `changeForgotPassword` Mutation
 - Docker CI GitHub Action will now add all the secrets in the `.env` file that are required to send an email.

### Node Packages Added
 - [googleapis](https://www.npmjs.com/package/googleapis)
 - [nodemailer](https://www.npmjs.com/package/nodemailer)
 - [uuid](https://www.npmjs.com/package/uuid)


### Screenshots

![image](https://user-images.githubusercontent.com/59534570/205959339-5d206ad2-89eb-4aea-93e5-ce40db9d51a9.png)
