### PR TITLE
feat(user-auth): add restrict username characters

### DIFF
--- a/src/resolvers/userResolver.js
+++ b/src/resolvers/userResolver.js
@@ -53,8 +53,19 @@ const userResolver = {
   Mutation: {
     register: async (_, { userInfo }, { req }) => {
       const { fullName, username, password, email } = userInfo;
-
       let user;
+
+      if (!validator.matches(username, "^[a-zA-Z0-9_-]+$")) {
+        return {
+          errors: [
+            {
+              field: "username",
+              message:
+                "username should only contain alphanumeric, - and _ characters",
+            },
+          ],
+        };
+      }
 
       try {
         const hashedPassword = await bcrypt.hash(password, saltRounds);


### PR DESCRIPTION
<h1>#91</h1>

This PR adds the functionality to restrict username characters in the username field to alphanumeric characters (A–Z, a–z and 0–9, case-sensitive) with the addition of `- ` and  `_`.

<h3>Changes</h3>

- Updated `register` mutation in `userResolver.js` to restrict username characters to alphanumeric characters (A–Z, a–z and 0–9, case-sensitive) , `_` and `-`.